### PR TITLE
fix: remove privileged from darwin

### DIFF
--- a/packages/flake/flake.sh
+++ b/packages/flake/flake.sh
@@ -269,7 +269,7 @@ privileged() {
 system-rebuild() {
 	if [[ "$is_darwin" == true ]]; then
 		cmd="darwin-rebuild $@"
-		privileged $cmd
+		$cmd
 	else
 		cmd="nixos-rebuild $@"
 		privileged $cmd


### PR DESCRIPTION
Closes: https://github.com/snowfallorg/flake/issues/5

Per response generated from [homebrew](https://docs.brew.sh/FAQ#why-does-homebrew-say-sudo-is-bad) nix-darwin homebrew module will fail to run while executed as sudo. nix-darwin will request elevated privileges when it detects its not run with [sudo](https://github.com/LnL7/nix-darwin/blob/master/pkgs/nix-tools/darwin-rebuild.sh#L206) on it's own. 