### PR TITLE
feat: flake command compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,114 @@ flake switch github:jakehamilton/config#bismuth
 flake switch github:jakehamilton/config --pick
 ```
 
+### `flake test`
+
+Test a system configuration
+
+```bash
+flake test
+
+DESCRIPTION
+
+  Test a system configuration with support for both NixOS and nix-darwin.
+
+USAGE
+
+  $ flake test <name> [options]
+
+OPTIONS
+
+  --help, -h                          Show this help message
+  --debug                             Show debug messages
+  --show-trace                        Show a trace when a Nix command fails
+
+EXAMPLES
+
+  # Test a configuration with the same hostname from the flake in the current directory.
+  $ flake test
+
+  # Test a specific configuration from the flake in the current directory.
+  $ flake test my-system
+
+  # Pick a configuration to test from the flake in the current directory.
+  $ flake test --pick
+
+  # Test a configuration from a specific flake.
+  $ flake test github:jakehamilton/config#bismuth
+
+  # Pick configuration from a specific flake.
+  $ flake test github:jakehamilton/config --pick
+```
+
+### `flake boot`
+
+Update the system's bootable generations.
+
+```bash
+flake boot
+
+DESCRIPTION
+
+  Set a NixOS configuration as the bootable system.
+
+USAGE
+
+  $ flake boot <name> [options]
+
+OPTIONS
+
+  --help, -h                          Show this help message
+  --debug                             Show debug messages
+  --show-trace                        Show a trace when a Nix command fails
+
+EXAMPLES
+
+  # Boot a configuration with the same hostname from the flake in the current directory.
+  $ flake boot
+
+  # Boot a specific configuration from the flake in the current directory.
+  $ flake boot my-system
+
+  # Pick a configuration to boot from the flake in the current directory.
+  $ flake boot --pick
+
+  # Boot a configuration from a specific flake.
+  $ flake boot github:jakehamilton/config#bismuth
+
+  # Pick configuration from a specific flake.
+  $ flake boot github:jakehamilton/config --pick
+```
+
+### `flake show`
+
+Show flake outputs.
+
+```bash
+flake show
+
+DESCRIPTION
+
+  Show the outputs of a Nix Flake.
+
+USAGE
+
+  $ flake show <name> [options]
+
+OPTIONS
+
+  --help, -h                          Show this help message
+  --debug                             Show debug messages
+  --show-trace                        Show a trace when a Nix command fails
+
+EXAMPLES
+
+  # Show outputs from the flake in the current directory.
+  $ flake show
+
+  # Show outputs from a specific flake.
+  $ flake show github:jakehamilton/config
+```
+
 ### `flake update`
 
 Update a Nix Flake's inputs.

--- a/packages/flake/flake.sh
+++ b/packages/flake/flake.sh
@@ -653,6 +653,27 @@ flake_boot() {
 	fi
 }
 
+flake_show() {
+	if [[ $opt_help == true ]]; then
+		show_help show
+		exit 0
+	fi
+	echo args: ${#positional_args[@]}
+
+	if [[ ${#positional_args[@]} > 2 ]]; then
+		log_fatal "${text_bold}flake show${text_reset} received too many positional arguments."
+	fi
+
+	if [[ ${#positional_args[@]} == 1 ]]; then
+		require_flake_nix
+		log_debug "Showing flake .#"
+		nix flake show .#
+	else
+		log_debug "Showing flake ${positional_args[1]}"
+		nix flake show ${positional_args[1]}
+	fi
+}
+
 flake_build() {
 	if [[ $opt_help == true ]]; then
 		show_help build
@@ -1193,8 +1214,8 @@ case ${positional_args[0]} in
 		flake_boot
 		;;
 	show)
-		log_debug "Running subcommand: ${text_bold}flake_switch${text_reset}"
-		flake_switch
+		log_debug "Running subcommand: ${text_bold}flake_show${text_reset}"
+		flake_show
 		;;
 	build)
 		log_debug "Running subcommand: ${text_bold}flake_build${text_reset}"

--- a/packages/flake/help/boot.sh
+++ b/packages/flake/help/boot.sh
@@ -1,0 +1,34 @@
+echo -e "
+${text_bold}${text_fg_blue}flake${text_reset} ${text_fg_white}boot${text_reset}
+
+${text_bold}DESCRIPTION${text_reset}
+
+  Set a NixOS configuration as the bootable system.
+
+${text_bold}USAGE${text_reset}
+
+  ${text_dim}\$${text_reset} ${text_bold}flake boot${text_reset} <name> [options]
+
+${text_bold}OPTIONS${text_reset}
+
+  --help, -h                          Show this help message
+  --debug                             Show debug messages
+  --show-trace                        Show a trace when a Nix command fails
+
+${text_bold}EXAMPLES${text_reset}
+
+  ${text_dim}# Boot a configuration with the same hostname from the flake in the current directory.${text_reset}
+  ${text_dim}\$${text_reset} ${text_bold}flake boot${text_reset}
+
+  ${text_dim}# Boot a specific configuration from the flake in the current directory.${text_reset}
+  ${text_dim}\$${text_reset} ${text_bold}flake boot${text_reset} ${text_underline}my-system${text_reset}
+
+  ${text_dim}# Pick a configuration to boot from the flake in the current directory.${text_reset}
+  ${text_dim}\$${text_reset} ${text_bold}flake boot${text_reset} --pick
+
+  ${text_dim}# Boot a configuration from a specific flake.${text_reset}
+  ${text_dim}\$${text_reset} ${text_bold}flake boot${text_reset} ${text_underline}github:jakehamilton/config#bismuth${text_reset}
+
+  ${text_dim}# Pick configuration from a specific flake.${text_reset}
+  ${text_dim}\$${text_reset} ${text_bold}flake boot${text_reset} ${text_underline}github:jakehamilton/config${text_reset} --pick
+"

--- a/packages/flake/help/flake.sh
+++ b/packages/flake/help/flake.sh
@@ -17,6 +17,9 @@ ${text_bold}COMMANDS${text_reset}
   run                       Run an app
   build                     Build a package
   switch                    Switch system configuration
+  test                      Test a system configuration
+  boot                      Update the system's bootable generations
+  show                      Show flake outputs
   update                    Update flake inputs
   build-<target>            Build a target system, see ${text_bold}flake build-system --help${text_reset}
   option                    Show NixOS options

--- a/packages/flake/help/show.sh
+++ b/packages/flake/help/show.sh
@@ -1,0 +1,25 @@
+echo -e "
+${text_bold}${text_fg_blue}flake${text_reset} ${text_fg_white}show${text_reset}
+
+${text_bold}DESCRIPTION${text_reset}
+
+  Show the outputs of a Nix Flake.
+
+${text_bold}USAGE${text_reset}
+
+  ${text_dim}\$${text_reset} ${text_bold}flake show${text_reset} <name> [options]
+
+${text_bold}OPTIONS${text_reset}
+
+  --help, -h                          Show this help message
+  --debug                             Show debug messages
+  --show-trace                        Show a trace when a Nix command fails
+
+${text_bold}EXAMPLES${text_reset}
+
+  ${text_dim}# Show outputs from the flake in the current directory.${text_reset}
+  ${text_dim}\$${text_reset} ${text_bold}flake show${text_reset}
+
+  ${text_dim}# Show outputs from a specific flake.${text_reset}
+  ${text_dim}\$${text_reset} ${text_bold}flake show${text_reset} ${text_underline}github:jakehamilton/config${text_reset}
+"

--- a/packages/flake/help/test.sh
+++ b/packages/flake/help/test.sh
@@ -1,0 +1,34 @@
+echo -e "
+${text_bold}${text_fg_blue}flake${text_reset} ${text_fg_white}test${text_reset}
+
+${text_bold}DESCRIPTION${text_reset}
+
+  Test a system configuration with support for both NixOS and nix-darwin.
+
+${text_bold}USAGE${text_reset}
+
+  ${text_dim}\$${text_reset} ${text_bold}flake test${text_reset} <name> [options]
+
+${text_bold}OPTIONS${text_reset}
+
+  --help, -h                          Show this help message
+  --debug                             Show debug messages
+  --show-trace                        Show a trace when a Nix command fails
+
+${text_bold}EXAMPLES${text_reset}
+
+  ${text_dim}# Test a configuration with the same hostname from the flake in the current directory.${text_reset}
+  ${text_dim}\$${text_reset} ${text_bold}flake test${text_reset}
+
+  ${text_dim}# Test a specific configuration from the flake in the current directory.${text_reset}
+  ${text_dim}\$${text_reset} ${text_bold}flake test${text_reset} ${text_underline}my-system${text_reset}
+
+  ${text_dim}# Pick a configuration to test from the flake in the current directory.${text_reset}
+  ${text_dim}\$${text_reset} ${text_bold}flake test${text_reset} --pick
+
+  ${text_dim}# Test a configuration from a specific flake.${text_reset}
+  ${text_dim}\$${text_reset} ${text_bold}flake test${text_reset} ${text_underline}github:jakehamilton/config#bismuth${text_reset}
+
+  ${text_dim}# Pick configuration from a specific flake.${text_reset}
+  ${text_dim}\$${text_reset} ${text_bold}flake test${text_reset} ${text_underline}github:jakehamilton/config${text_reset} --pick
+"


### PR DESCRIPTION
We were missing some features that the `nix flake` and `nixos-rebuild` (or `darwin-rebuild`) provided. This PR adds support for `flake test`, `flake boot`, and `flake show`.

fixes #7 