### PR TITLE
Replace depreciated substituteAll with replaceVarsWith

### DIFF
--- a/packages/flake/default.nix
+++ b/packages/flake/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenvNoCC
-, substituteAll
+, replaceVarsWith
 , gum
 , nixos-option
 , writeShellApplication
@@ -9,7 +9,7 @@
 }:
 
 let
-  substitute = args: builtins.readFile (substituteAll args);
+  substitute = args: builtins.readFile (replaceVarsWith args);
 
   filter-flake = writeShellApplication {
     name = "filter-flake";
@@ -35,9 +35,11 @@ writeShellApplication {
   text = substitute {
     src = ./flake.sh;
 
-    help = ./help;
-    flakeCompat = inputs.flake-compat;
-    isDarwin = if stdenvNoCC.isDarwin then "true" else "false";
+    replacements = {
+      help = ./help;
+      flakeCompat = inputs.flake-compat;
+      isDarwin = if stdenvNoCC.isDarwin then "true" else "false";
+    };
   };
   checkPhase = "";
   runtimeInputs = [


### PR DESCRIPTION
With 25.05, `substituteAll` is depreciated, and in 25.11/unstable it is no more.

The replacement that is most similar to your use is `replaceVarsWith`, which needs the substitutions in a `replacements` set.